### PR TITLE
docs: Fix simple typo, optionaly -> optionally

### DIFF
--- a/docs/source/config/live.rst
+++ b/docs/source/config/live.rst
@@ -73,7 +73,7 @@ set your configuration
         'db': 0,
     }
 
-optionaly 
+optionally 
 
 .. code-block:: python
 

--- a/docs/source/extends/new_theme.rst
+++ b/docs/source/extends/new_theme.rst
@@ -8,7 +8,7 @@ Best example is live code, we have two base themes for you and lives under main 
 * AdminLTE - https://github.com/django-leonardo/leonardo-theme-adminlte
 * Bootswatch - https://github.com/django-leonardo/leonardo-theme-bootswatch
 
-As you can see theme must contains one template for page layout and optionaly base css for this layout and some color variations lives in ``skins`` directory.
+As you can see theme must contains one template for page layout and optionally base css for this layout and some color variations lives in ``skins`` directory.
 
 Directory structure::
 

--- a/leonardo/config.py
+++ b/leonardo/config.py
@@ -32,7 +32,7 @@ class LeonardoConfig(AppConfig):
         from horizon.conf import HORIZON_CONFIG
         from horizon import conf as horizon_conf
         try:
-            # optionaly copy all live configuration to horizon/leonardo
+            # optionally copy all live configuration to horizon/leonardo
             from constance import config
 
             for k in dir(config):

--- a/leonardo/module/web/__init__.py
+++ b/leonardo/module/web/__init__.py
@@ -47,21 +47,21 @@ class Default(object):
 
         INSTALLED_APPS = []
 
-        # optionaly enable sorl.thumbnail
+        # optionally enable sorl.thumbnail
         try:
             import sorl  # noqa
             INSTALLED_APPS += ['sorl.thumbnail']
         except Exception:
             pass
 
-        # optionaly enable easy_thumbnails
+        # optionally enable easy_thumbnails
         try:
             import easy_thumbnails  # noqa
             INSTALLED_APPS += ['easy_thumbnails']
         except Exception:
             pass
 
-        # optionaly enable constance
+        # optionally enable constance
         try:
             import constance
         except ImportError:

--- a/leonardo/module/web/admin.py
+++ b/leonardo/module/web/admin.py
@@ -155,7 +155,7 @@ class PageAdmin(FeinPageAdmin):
             initial['theme'] = original.theme
             initial['color_scheme'] = original.color_scheme
 
-            # optionaly translate title and make slug
+            # optionally translate title and make slug
             old_lang = translation.get_language()
             translation.activate(request.GET.get('language'))
             title = _(original.title)

--- a/leonardo/templatetags/leonardo_page_tags.py
+++ b/leonardo/templatetags/leonardo_page_tags.py
@@ -33,7 +33,7 @@ class LanguageLinksNode(SimpleAssignmentNodeWithVarAndArgs):
         trailing_path = ''
         request = args.get('request', None)
         if request:
-            # optionaly if is there request use app extra
+            # optionally if is there request use app extra
             try:
                 # Trailing path without first slash
                 trailing_path = request._feincms_extra_context.get(

--- a/leonardo/utils/widgets.py
+++ b/leonardo/utils/widgets.py
@@ -66,7 +66,7 @@ def get_grouped_widgets(feincms_object, request=None):
 
     requires feincms_object for getting content types
 
-    request optionaly for checking permissions, but not required
+    request optionally for checking permissions, but not required
 
     grouped = {'web': (id, label, icon)}
     '''


### PR DESCRIPTION
There is a small typo in docs/source/config/live.rst, docs/source/extends/new_theme.rst, leonardo/config.py, leonardo/module/web/__init__.py, leonardo/module/web/admin.py, leonardo/templatetags/leonardo_page_tags.py, leonardo/utils/widgets.py.

Should read `optionally` rather than `optionaly`.

